### PR TITLE
Fix cookies blocked

### DIFF
--- a/wordpress.vcl
+++ b/wordpress.vcl
@@ -68,6 +68,10 @@ sub vcl_hit {
 }
 
 sub vcl_miss {
+  if (!(req.url ~ "wp-(login|admin)")) {
+    unset req.http.cookie;
+  }
+  
   if (req.method == "PURGE") {
     return (synth(404, "Not cached"));
   }


### PR DESCRIPTION
Fix the wordpress error: Cookies are blocked or not supported by your browser